### PR TITLE
Add prefix listing in mongodb_store.go

### DIFF
--- a/weed/filer/mongodb/mongodb_store.go
+++ b/weed/filer/mongodb/mongodb_store.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -229,16 +230,20 @@ func (store *MongodbStore) DeleteFolderChildren(ctx context.Context, fullpath ut
 }
 
 func (store *MongodbStore) ListDirectoryPrefixedEntries(ctx context.Context, dirPath util.FullPath, startFileName string, includeStartFile bool, limit int64, prefix string, eachEntryFunc filer.ListEachEntryFunc) (lastFileName string, err error) {
-	return lastFileName, filer.ErrUnsupportedListDirectoryPrefixed
-}
-
-func (store *MongodbStore) ListDirectoryEntries(ctx context.Context, dirPath util.FullPath, startFileName string, includeStartFile bool, limit int64, eachEntryFunc filer.ListEachEntryFunc) (lastFileName string, err error) {
-	var where = bson.M{"directory": string(dirPath), "name": bson.M{"$gt": startFileName}}
-	if includeStartFile {
-		where["name"] = bson.M{
-			"$gte": startFileName,
-		}
+	where := bson.M{
+		"directory": string(dirPath),
 	}
+
+	if len(prefix) > 0 {
+		where["name"].(bson.M)["$regex"] = "^" + regexp.QuoteMeta(prefix)
+	}
+
+	if includeStartFile {
+		where["name"].(bson.M)["$gte"] = startFileName
+	} else {
+		where["name"].(bson.M)["$gt"] = startFileName
+	}
+		
 	optLimit := int64(limit)
 	opts := &options.FindOptions{Limit: &optLimit, Sort: bson.M{"name": 1}}
 	cur, err := store.connect.Database(store.database).Collection(store.collectionName).Find(ctx, where, opts)
@@ -274,6 +279,10 @@ func (store *MongodbStore) ListDirectoryEntries(ctx context.Context, dirPath uti
 	}
 
 	return lastFileName, err
+}
+
+func (store *MongodbStore) ListDirectoryEntries(ctx context.Context, dirPath util.FullPath, startFileName string, includeStartFile bool, limit int64, eachEntryFunc filer.ListEachEntryFunc) (lastFileName string, err error) {
+	return store.ListDirectoryPrefixedEntries(ctx, dirPath, startFileName, includeStartFile, limit, "", eachEntryFunc)
 }
 
 func (store *MongodbStore) Shutdown() {


### PR DESCRIPTION
# What problem are we solving?
Mongodb filer not supported ListDirectoryPrefixedEntries method on database level, which will work faster on folders with hight files count.


# How are we solving the problem?
Implemented ListDirectoryPrefixedEntries using mongodb regex search. Regex search by prefix uses index while executed, so searching time is ok.


# How is the PR tested?
Run local aio deployment with mongodb filer store setted up. Confirm same beheviour with prefixFilterEntries version (when err ErrUnsupportedListDirectoryPrefixed raised)

